### PR TITLE
FIX - HA integration does not report status back to HA

### DIFF
--- a/src/HAIntegration.cpp
+++ b/src/HAIntegration.cpp
@@ -47,6 +47,7 @@ void HAIntegration::configure() {
 
 void HAIntegration::switchHandler(bool state, HASwitch* sender) {
     digitalWrite(LED_PIN, (state ? HIGH : LOW));
+    sender->setState(state);  // report state back to Home Assistant
 }
 
 


### PR DESCRIPTION
When the LED state changes it should report this change back to HA so the UI is updated appropriately. At the moment when you turn the LED on HA doesn't report as being switched on and therefore you cannot turn it back off.