### PR TITLE
Update Home Assistant Integration

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -15,7 +15,7 @@ board = rpipicow
 board_build.core = earlephilhower
 monitor_filters = time
 lib_deps = 
-	https://github.com/dawidchyrzynski/arduino-home-assistant
+	dawidchyrzynski/home-assistant-integration@^2.1.0
 	knolleary/PubSubClient@^2.8
 extra_scripts = 
 	post:mac-post-upload.py


### PR DESCRIPTION
Update Home Assistant Integration. 2.1.0 released some useful features: (https://github.com/dawidchyrzynski/arduino-home-assistant/releases/tag/2.1.0)[https://github.com/dawidchyrzynski/arduino-home-assistant/releases/tag/2.1.0]